### PR TITLE
add category management with enable/disable, search, and select all

### DIFF
--- a/lib/backend/db_factory.dart
+++ b/lib/backend/db_factory.dart
@@ -121,6 +121,15 @@ class DbFactory {
         await tx.execute('''
           CREATE INDEX index_groups_media_type ON groups(media_type);
         ''');
+      }))
+      ..add(SqliteMigration(4, (tx) async {
+        await tx.execute('''
+          ALTER TABLE groups
+          ADD COLUMN enabled integer DEFAULT 1;
+        ''');
+        await tx.execute('''
+          CREATE INDEX index_groups_enabled ON groups(enabled);
+        ''');
       }));
     await migrations.migrate(db);
     return db;

--- a/lib/backend/sql.dart
+++ b/lib/backend/sql.dart
@@ -158,13 +158,17 @@ class Sql {
         ? query.split(" ").map((f) => "%$f%").toList()
         : ["%$query%"];
     var sqlQuery = '''
-        SELECT * FROM channels 
+        SELECT * FROM channels
         WHERE (${getKeywordsSql(keywords.length)})
         AND media_type IN (${generatePlaceholders(mediaTypes.length)})
         AND source_id IN (${generatePlaceholders(filters.sourceIds!.length)})
         AND url IS NOT NULL
     ''';
     List<Object> params = [];
+    if (filters.enabledGroupIds != null && filters.enabledGroupIds!.isNotEmpty) {
+      sqlQuery +=
+          "\nAND (group_id IS NULL OR group_id IN (${generatePlaceholders(filters.enabledGroupIds!.length)}))";
+    }
     if (filters.viewType == ViewType.favorites && filters.seriesId == null) {
       sqlQuery += "\nAND favorite = 1";
     }
@@ -181,6 +185,9 @@ class Sql {
     params.addAll(keywords);
     params.addAll(mediaTypes);
     params.addAll(filters.sourceIds!);
+    if (filters.enabledGroupIds != null && filters.enabledGroupIds!.isNotEmpty) {
+      params.addAll(filters.enabledGroupIds!);
+    }
     if (filters.seriesId != null) {
       params.add(filters.seriesId!);
     } else if (filters.groupId != null) {
@@ -224,10 +231,11 @@ class Sql {
         : ["%$query%"];
     var mediaTypes = filters.mediaTypes!.map((x) => x.index);
     var sqlQuery = '''
-        SELECT * FROM groups 
+        SELECT * FROM groups
         WHERE (${getKeywordsSql(keywords.length)})
         AND (media_type IS NULL OR media_type IN (${generatePlaceholders(mediaTypes.length)}))
         AND source_id IN (${generatePlaceholders(filters.sourceIds!.length)})
+        AND enabled = 1
         LIMIT ?, ?
     ''';
     List<Object> params = [];
@@ -375,10 +383,53 @@ class Sql {
   static Future<void> setSourceEnabled(bool enabled, int sourceId) async {
     var db = await DbFactory.db;
     await db.execute('''
-      UPDATE sources 
-      SET enabled = ? 
+      UPDATE sources
+      SET enabled = ?
       WHERE id = ?
     ''', [enabled, sourceId]);
+  }
+
+  static Future<void> setGroupEnabled(bool enabled, int groupId) async {
+    var db = await DbFactory.db;
+    await db.execute('''
+      UPDATE groups
+      SET enabled = ?
+      WHERE id = ?
+    ''', [enabled ? 1 : 0, groupId]);
+  }
+
+  static Future<void> setAllGroupsEnabled(bool enabled) async {
+    var db = await DbFactory.db;
+    await db.execute('''
+      UPDATE groups
+      SET enabled = ?
+    ''', [enabled ? 1 : 0]);
+  }
+
+  static Future<List<Map<String, dynamic>>> getGroups() async {
+    var db = await DbFactory.db;
+    var results = await db.getAll('''
+      SELECT g.id, g.name, g.enabled, s.name as source_name
+      FROM groups g
+      JOIN sources s ON g.source_id = s.id
+      ORDER BY s.name, g.name
+    ''');
+    return results
+        .map((row) => {
+              'id': row.columnAt(0) as int,
+              'name': row.columnAt(1) as String,
+              'enabled': row.columnAt(2) == 1,
+              'sourceName': row.columnAt(3) as String,
+            })
+        .toList();
+  }
+
+  static Future<List<int>> getEnabledGroupIds() async {
+    var db = await DbFactory.db;
+    var results = await db.getAll('''
+      SELECT id FROM groups WHERE enabled = 1
+    ''');
+    return results.map((row) => row.columnAt(0) as int).toList();
   }
 
   static Future setPosition(int channelId, int seconds) async {

--- a/lib/channel_tile.dart
+++ b/lib/channel_tile.dart
@@ -34,14 +34,19 @@ class _ChannelTileState extends State<ChannelTile> {
   void initState() {
     super.initState();
     _focusNode.onKeyEvent = (node, event) {
-      if (event is KeyDownEvent &&
-          event.logicalKey == LogicalKeyboardKey.arrowRight) {
-        if (!FocusScope.of(
-          context,
-        ).focusInDirection(TraversalDirection.right)) {
-          widget.onFocusNavbar?.call();
+      if (event is KeyDownEvent) {
+        if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
+          if (!FocusScope.of(
+            context,
+          ).focusInDirection(TraversalDirection.right)) {
+            widget.onFocusNavbar?.call();
+          }
+          return KeyEventResult.handled;
         }
-        return KeyEventResult.handled;
+        if (event.logicalKey == LogicalKeyboardKey.mediaPlayPause) {
+          favorite();
+          return KeyEventResult.handled;
+        }
       }
       return KeyEventResult.ignored;
     };

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -61,6 +61,9 @@ class _HomeState extends State<Home> {
       widget.home.filters.mediaTypes = (await SettingsService.getSettings())
           .getMediaTypes();
     }
+    if (widget.home.filters.enabledGroupIds == null) {
+      widget.home.filters.enabledGroupIds = await Sql.getEnabledGroupIds();
+    }
     await load();
     final String? version = await SettingsService.shouldShowWhatsNew();
     if (widget.firstLaunch && version != null) {
@@ -169,6 +172,7 @@ class _HomeState extends State<Home> {
               viewType: type,
               mediaTypes: widget.home.filters.mediaTypes,
               sourceIds: widget.home.filters.sourceIds,
+              enabledGroupIds: widget.home.filters.enabledGroupIds,
             ),
           ),
         ),
@@ -184,6 +188,7 @@ class _HomeState extends State<Home> {
         viewType: ViewType.all,
         mediaTypes: widget.home.filters.mediaTypes,
         sourceIds: widget.home.filters.sourceIds,
+        enabledGroupIds: widget.home.filters.enabledGroupIds,
       ),
     );
     if (widget.home.filters.groupId != null) {

--- a/lib/models/filters.dart
+++ b/lib/models/filters.dart
@@ -9,6 +9,7 @@ class Filters {
   int page;
   int? seriesId;
   int? groupId;
+  List<int>? enabledGroupIds;
   bool useKeywords;
 
   Filters({
@@ -19,6 +20,7 @@ class Filters {
     this.page = 1,
     this.seriesId,
     this.groupId,
+    this.enabledGroupIds,
     this.useKeywords = false,
   });
 }

--- a/lib/settings_view.dart
+++ b/lib/settings_view.dart
@@ -529,7 +529,7 @@ class _SettingsState extends State<SettingsView> {
                       padding: const EdgeInsets.symmetric(horizontal: 10),
                       child: TextField(
                         focusNode: _searchFocusNode,
-                        readOnly: _searchReadOnly,
+                        readOnly: !widget.showNavBar && _searchReadOnly,
                         decoration: const InputDecoration(
                           hintText: 'Search categories...',
                           prefixIcon: Icon(Icons.search),

--- a/lib/settings_view.dart
+++ b/lib/settings_view.dart
@@ -31,6 +31,8 @@ class SettingsView extends StatefulWidget {
 class _SettingsState extends State<SettingsView> {
   Settings settings = Settings();
   List<Source> sources = [];
+  List<Map<String, dynamic>> categories = [];
+  String _categorySearch = '';
   bool loading = true;
   @override
   void initState() {
@@ -42,10 +44,12 @@ class _SettingsState extends State<SettingsView> {
     var results = await Future.wait([
       SettingsService.getSettings(),
       Sql.getSources(),
+      Sql.getGroups(),
     ]);
     setState(() {
       settings = results[0] as Settings;
       sources = results[1] as List<Source>;
+      categories = results[2] as List<Map<String, dynamic>>;
       loading = false;
     });
   }
@@ -187,6 +191,79 @@ class _SettingsState extends State<SettingsView> {
             );
           }
         },
+      ),
+    );
+  }
+
+  Future<void> toggleCategory(Map<String, dynamic> category) async {
+    await Error.tryAsyncNoLoading(
+      () async =>
+          await Sql.setGroupEnabled(!(category['enabled'] as bool), category['id'] as int),
+      context,
+    );
+    await reloadCategories();
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content:
+            Text("Category ${!(category['enabled'] as bool) ? "enabled" : "disabled"}"),
+        duration: const Duration(milliseconds: 500),
+      ),
+    );
+  }
+
+  Future<void> setAllCategoriesEnabled(bool enabled) async {
+    await Error.tryAsyncNoLoading(
+      () async => await Sql.setAllGroupsEnabled(enabled),
+      context,
+    );
+    await reloadCategories();
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text("All categories ${enabled ? "enabled" : "disabled"}"),
+        duration: const Duration(milliseconds: 500),
+      ),
+    );
+  }
+
+  Future<void> reloadCategories() async {
+    await Error.tryAsyncNoLoading(
+      () async => categories = await Sql.getGroups(),
+      context,
+    );
+    setState(() {
+      categories;
+    });
+  }
+
+  List<Map<String, dynamic>> get filteredCategories {
+    if (_categorySearch.isEmpty) return categories;
+    final query = _categorySearch.toLowerCase();
+    return categories
+        .where((c) =>
+            (c['name'] as String).toLowerCase().contains(query) ||
+            (c['sourceName'] as String).toLowerCase().contains(query))
+        .toList();
+  }
+
+  Widget getCategory(Map<String, dynamic> category) {
+    final enabled = category['enabled'] as bool;
+    return Card(
+      margin: const EdgeInsets.symmetric(
+        horizontal: 10,
+        vertical: 5,
+      ),
+      elevation: 5,
+      child: ListTile(
+        leading: Checkbox(
+          value: enabled,
+          onChanged: (_) => toggleCategory(category),
+        ),
+        onTap: () => toggleCategory(category),
+        contentPadding: const EdgeInsets.only(left: 10),
+        title: Text(category['name'] as String),
+        subtitle: Text(category['sourceName'] as String),
       ),
     );
   }
@@ -373,6 +450,58 @@ class _SettingsState extends State<SettingsView> {
                   ),
                   const SizedBox(height: 10),
                   ...sources.map(getSource),
+                  if (categories.isNotEmpty) ...[
+                    const Divider(),
+                    const Padding(
+                      padding: EdgeInsets.only(left: 10),
+                      child: Text(
+                        'Categories',
+                        style: TextStyle(
+                          fontSize: 30,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.only(left: 4),
+                      child: Row(
+                        children: [
+                          Checkbox(
+                            value: categories.every((c) => c['enabled'] as bool),
+                            tristate: true,
+                            onChanged: (value) {
+                              final allEnabled = categories.every((c) => c['enabled'] as bool);
+                              setAllCategoriesEnabled(!allEnabled);
+                            },
+                          ),
+                          GestureDetector(
+                            onTap: () {
+                              final allEnabled = categories.every((c) => c['enabled'] as bool);
+                              setAllCategoriesEnabled(!allEnabled);
+                            },
+                            child: const Text('Select All'),
+                          ),
+                        ],
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 10),
+                      child: TextField(
+                        decoration: const InputDecoration(
+                          hintText: 'Search categories...',
+                          prefixIcon: Icon(Icons.search),
+                          isDense: true,
+                        ),
+                        onChanged: (value) {
+                          setState(() {
+                            _categorySearch = value;
+                          });
+                        },
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    ...filteredCategories.map(getCategory),
+                  ],
                 ],
               ),
             ),

--- a/lib/settings_view.dart
+++ b/lib/settings_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:open_tv/backend/settings_service.dart';
 import 'package:open_tv/backend/sql.dart';
 import 'package:open_tv/backend/utils.dart';
@@ -34,10 +35,50 @@ class _SettingsState extends State<SettingsView> {
   List<Map<String, dynamic>> categories = [];
   String _categorySearch = '';
   bool loading = true;
+  bool _searchReadOnly = true;
+  late final FocusNode _searchFocusNode;
   @override
   void initState() {
     super.initState();
+    _searchFocusNode = FocusNode(
+      onKeyEvent: (node, event) {
+        if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+          return KeyEventResult.ignored;
+        }
+        if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+          setState(() => _searchReadOnly = true);
+          node.nextFocus();
+          return KeyEventResult.handled;
+        }
+        if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+          setState(() => _searchReadOnly = true);
+          node.previousFocus();
+          return KeyEventResult.handled;
+        }
+        if (event.logicalKey == LogicalKeyboardKey.enter ||
+            event.logicalKey == LogicalKeyboardKey.select) {
+          if (_searchReadOnly) {
+            setState(() => _searchReadOnly = false);
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        }
+        if (event.logicalKey == LogicalKeyboardKey.escape ||
+            event.logicalKey == LogicalKeyboardKey.goBack) {
+          setState(() => _searchReadOnly = true);
+          node.unfocus();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+    );
     initAsync();
+  }
+
+  @override
+  void dispose() {
+    _searchFocusNode.dispose();
+    super.dispose();
   }
 
   Future<void> initAsync() async {
@@ -487,6 +528,8 @@ class _SettingsState extends State<SettingsView> {
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 10),
                       child: TextField(
+                        focusNode: _searchFocusNode,
+                        readOnly: _searchReadOnly,
                         decoration: const InputDecoration(
                           hintText: 'Search categories...',
                           prefixIcon: Icon(Icons.search),


### PR DESCRIPTION
Add enabled column to groups table (migration 4), filter channels by enabled categories, and add a Categories section in settings with checkboxes, select all toggle, and search bar.

works on android app and android tv, also added pause button to enable/disable selecting channel as favorite

category enable/disable filtering:
<img width="862" height="1264" alt="image" src="https://github.com/user-attachments/assets/24f151f0-c7f1-4404-b57b-00d51b17f4da" />

category view after selection:
<img width="832" height="1708" alt="image" src="https://github.com/user-attachments/assets/5fae9247-d785-41f9-afea-d3cf35a153a4" />
