### PR TITLE
move the skipSetup check to the top so it's evaluated first

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -101,20 +101,19 @@ class MyApp extends StatelessWidget {
       ),
       themeMode: ThemeMode.dark,
       debugShowCheckedModeBanner: false,
-      home:
-          settings.forceTVMode ||
+      home: !skipSetup
+          ? const Setup()
+          : settings.forceTVMode ||
               isTV ||
               (!hasTouchScreen && (Platform.isAndroid || Platform.isIOS))
           ? TvHome()
-          : skipSetup
-          ? Home(
+          : Home(
               firstLaunch: true,
               refresh: settings.refreshOnStart,
               home: HomeManager(
                 filters: Filters(viewType: settings.defaultView),
               ),
-            )
-          : const Setup(),
+            ),
     );
   }
 }


### PR DESCRIPTION
In main.dart:104-117, the TV mode check comes first and always routes to TvHome() without checking skipSetup. When it's a TV (or forceTVMode or no touchscreen on Android/iOS), it goes straight to TvHome() regardless of whether sources exist.

This fixes starting the setup wizard on a new android tv install